### PR TITLE
fix for PC prior utility functions in gamma / gama count model

### DIFF
--- a/rinla/R/pc-gamma.R
+++ b/rinla/R/pc-gamma.R
@@ -74,11 +74,11 @@ inla.pc.dgamma <- function(x, lambda = 1, log = FALSE) {
 }
 
 inla.pc.qgamma <- function(p, lambda = 1) {
-    log.x <- inla.pmarginal(p, inla.pc.gamma.intern(lambda = lambda))
+    log.x <- inla.qmarginal(p, inla.pc.gamma.intern(lambda = lambda))
     return(exp(log.x))
 }
 
 inla.pc.pgamma <- function(q, lambda = 1) {
-    p <- inla.qmarginal(log(q), inla.pc.gamma.intern(lambda = lambda))
+    p <- inla.pmarginal(log(q), inla.pc.gamma.intern(lambda = lambda))
     return(p)
 }

--- a/rinla/R/pc-gammacount.R
+++ b/rinla/R/pc-gammacount.R
@@ -89,11 +89,11 @@ inla.pc.dgammacount <- function(x, lambda = 1, log = FALSE) {
 }
 
 inla.pc.qgammacount <- function(p, lambda = 1) {
-    log.x <- inla.pmarginal(p, inla.pc.gammacount.intern(lambda = lambda))
+    log.x <- inla.qmarginal(p, inla.pc.gammacount.intern(lambda = lambda))
     return(exp(log.x))
 }
 
 inla.pc.pgammacount <- function(q, lambda = 1) {
-    p <- inla.qmarginal(log(q), inla.pc.gammacount.intern(lambda = lambda))
+    p <- inla.pmarginal(log(q), inla.pc.gammacount.intern(lambda = lambda))
     return(p)
 }


### PR DESCRIPTION
Dear INLA team,

It seems that `INLA::inla.pc.pgamma(1, lambda = 1)` gives a negative and thus non-sensical result for the lower tail probability of the penalized complexity prior in the Gamma(1/alpha, 1/alpha) model because the function computes a quantile from the internal representation of the distribution instead of a probability. Furthermore, `INLA::inla.pc.qgamma()` computes a probability instead of a quantile. 

This confusion of `inla.pmarginal()` and `inla.qmarginal()` also occurs in the utility functions of the gamma count model.

Hope this is helpful!

Best,
Martin