### PR TITLE
Fix BYM2 models failing because of new stopifnot() checks

### DIFF
--- a/rinla/R/pc-bym.R
+++ b/rinla/R/pc-bym.R
@@ -43,6 +43,7 @@ inla.sparse.det.bym <- function(Q,
     ## component >1. if 'constr' is given,  it is supposed to be the 'constr' that is
     ## constructed below.
 
+    adjust.for.con.comp <- as.logical(adjust.for.con.comp)
     stopifnot(adjust.for.con.comp)
     Q <- inla.as.sparse(Q)
     n <- dim(Q)[1]
@@ -119,6 +120,9 @@ inla.pc.bym.phi <- function(graph,
                             eps = sqrt(.Machine$double.eps),
                             debug = FALSE) {
     my.debug <- function(...) if (debug) cat("*** debug *** inla.pc.bym.phi: ", ..., "\n")
+
+    scale.model <- as.logical(scale.model)
+    adjust.for.con.comp <- as.logical(adjust.for.con.comp)
 
     ## I must assume this!!!
     stopifnot(scale.model)

--- a/rinla/R/sections.R
+++ b/rinla/R/sections.R
@@ -578,7 +578,7 @@ inla.parse.Bmatrix.test <- function() {
                     alpha = random.spec$hyper$theta2$param[2L],
                     scale.model = TRUE,
                     return.as.table = TRUE,
-                    adjust.for.con.comp = as.numeric(random.spec$adjust.for.con.comp)
+                    adjust.for.con.comp = random.spec$adjust.for.con.comp
                 )
                 random.spec$hyper$theta2$param <- numeric(0)
             } else if (inla.one.of(random.spec$model, "rw2diid")) {


### PR DESCRIPTION
In #4d96b4063c ("Run 'jarl' with '--fix'", merged 5 days ago), the auto-formatter rewrote `R/pc-bym.R`:

```diff
-    stopifnot(scale.model == TRUE)
-    stopifnot(adjust.for.con.comp == TRUE)
+    stopifnot(scale.model)
+    stopifnot(adjust.for.con.comp)
```

(plus the analogous change at `pc-bym.R:46` in `inla.sparse.det.bym`).

But `stopifnot(x == TRUE)` coerces to logical and accepts numeric `0/1`; `stopifnot(x)` requires strictly `TRUE` and errors on numeric `1` with `"1 is not TRUE"`. The single caller of `inla.pc.bym.phi()` at `R/sections.R:581` passes `as.numeric(random.spec$adjust.for.con.comp)`, i.e. `1`. As a result, every `bym2` model with the default PC prior on phi now fails during INI-file generation with:

```
Error: adjust.for.con.comp is not TRUE
```

The same bug is lying in wait at `pc-bym.R:124` for `scale.model`, but it doesn't bite today only because the call site happens to pass `TRUE` instead of `1`.

This PR coerces these arguments to logicals immediately before their `stopifnot()`s, so the checks are robust to numeric `0/1` from any caller (and to future formatter passes).
