### PR TITLE
Add Poisson Log-normal likelihood

### DIFF
--- a/inlaprog/src/inla-likelihood.c
+++ b/inlaprog/src/inla-likelihood.c
@@ -2794,12 +2794,17 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 	double *xq = NULL, *wq = NULL;
 	GMRFLib_ghq(&xq, &wq, nq);
 
-	/* Per-call working arrays allocated on the heap (size is user-controlled, malloc is portable C89). */
-	double *vk     = Malloc(nq, double);
-	double *log_wq = Malloc(nq, double);
-	double *xq2    = Malloc(nq, double);
-	double *vk2    = Malloc(nq, double);
-	double *vals   = Malloc(nq, double);
+	/*
+	 * Three heap arrays suffice. log_base[k] and E_expvks[k] are constant
+	 * across all m evaluations so they are precomputed once below.
+	 *
+	 * Key identity: E*exp(eta_i + vk[k]*sd) = E*exp(vk[k]*sd) * exp(eta_i)
+	 * This lets the inner k-loop avoid exp() entirely -- one exp(eta_i) per i
+	 * instead of nq exp() calls, halving the total exp() work.
+	 */
+	double *log_base = Malloc(nq, double); /* log(w_k)+normc - vk^2/2 + xq_k^2/2 + y*vk*sd */
+	double *E_expvks = Malloc(nq, double); /* E * exp(vk[k]*sd) */
+	double *vals     = Malloc(nq, double); /* per-i working buffer */
 
 	LINK_INIT;
 
@@ -2810,7 +2815,7 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 		/* Newton: find v* = argmax [ y*(eta_ref+v*sd) - E*exp(eta_ref+v*sd) - v^2/2 ]
 		 * Initialise at the Poisson mode (mu=y) to keep the first step small even when
 		 * eta_ref is far from the truth (starting at v=0 can give a step of ~y/mu_0). */
-		double v_star;
+		double v_star, mu_last;
 		int iter;
 		if (y > 0.0) {
 			v_star = (log(y / fmax(E, 1e-300)) - eta_ref) / sd;
@@ -2818,11 +2823,12 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 		} else {
 			v_star = 0.0;
 		}
+		mu_last = 0.0;
 		for (iter = 0; iter < 30; iter++) {
 			double eta_v = eta_ref + v_star * sd;
-			double mu_v = (eta_v < 500.0) ? E * exp(eta_v) : E * exp(500.0);
-			double gp = (y - mu_v) * sd - v_star;
-			double gpp = -(mu_v * sd2 + 1.0);
+			mu_last = (eta_v < 500.0) ? E * exp(eta_v) : E * exp(500.0);
+			double gp = (y - mu_last) * sd - v_star;
+			double gpp = -(mu_last * sd2 + 1.0);
 			double dv = fmax(-5.0, fmin(5.0, -gp / gpp));
 			v_star += dv;
 			if (fabs(dv) < 1e-8) {
@@ -2830,27 +2836,32 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 			}
 		}
 
+		/* mu_last is E*exp(eta_ref+v_star*sd) from the final Newton step.
+		 * Recompute only if the last iteration did not converge at the stored mu_last. */
 		double mu_star = E * exp(eta_ref + v_star * sd);
-		double sigma_a = 1.0 / sqrt(mu_star * sd2 + 1.0);
-		double log_sigma_a = -0.5 * log(mu_star * sd2 + 1.0);
+		double denom = mu_star * sd2 + 1.0;
+		double sigma_a = 1.0 / sqrt(denom);
+		double log_sigma_a = -0.5 * log(denom);
 
+		/* Precompute per-node constants (independent of eta_i). */
 		int k;
 		for (k = 0; k < nq; k++) {
-			vk[k]     = v_star + xq[k] * sigma_a;
-			log_wq[k] = log(wq[k]);
-			xq2[k]    = xq[k] * xq[k];
-			vk2[k]    = vk[k] * vk[k];
+			double vk_k  = v_star + xq[k] * sigma_a;
+			double vks_k = vk_k * sd;			       /* vk * sd */
+			log_base[k]  = log(wq[k]) + normc - 0.5 * vk_k * vk_k + 0.5 * xq[k] * xq[k] + y * vks_k;
+			E_expvks[k]  = E * exp(vks_k);
 		}
 
+		/* Inner loop: one exp(eta_i) per i; no exp inside the k-loop. */
 		int i;
 		for (i = 0; i < m; i++) {
-			double eta_i = PREDICTOR_INVERSE_IDENTITY_LINK(x[i], off);
-			double vmax = -INFINITY;
+			double eta_i     = PREDICTOR_INVERSE_IDENTITY_LINK(x[i], off);
+			double exp_eta_i = exp(eta_i);
+			double y_eta_i   = y * eta_i;
+			double vmax      = -INFINITY;
 
 			for (k = 0; k < nq; k++) {
-				double eta_k = eta_i + vk[k] * sd;
-				double mu_k = E * exp(eta_k);
-				vals[k] = log_wq[k] + normc + y * eta_k - mu_k - 0.5 * vk2[k] + 0.5 * xq2[k];
+				vals[k] = log_base[k] + y_eta_i - E_expvks[k] * exp_eta_i;
 				if (vals[k] > vmax) {
 					vmax = vals[k];
 				}
@@ -2858,9 +2869,7 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 
 			double sum = 0.0;
 			for (k = 0; k < nq; k++) {
-				if (!ISNAN(vals[k])) {
-					sum += exp(vals[k] - vmax);
-				}
+				sum += exp(vals[k] - vmax);
 			}
 			logll[i] = log_sigma_a + vmax + log(sum);
 		}
@@ -2868,10 +2877,8 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 
 	LINK_END;
 
-	Free(vk);
-	Free(log_wq);
-	Free(xq2);
-	Free(vk2);
+	Free(log_base);
+	Free(E_expvks);
 	Free(vals);
 
 #undef _pln_logE

--- a/inlaprog/src/inla-likelihood.c
+++ b/inlaprog/src/inla-likelihood.c
@@ -170,6 +170,7 @@ int inla_read_data_likelihood(inla_tp *mb, dictionary *UNUSED(ini), int UNUSED(s
 	case L_GAMMACOUNT:
 	case L_GPOISSON:
 	case L_POISSON:
+	case L_POISSONLOGNORMAL:
 	case L_NPOISSON:
 	case L_NZPOISSON:
 	case L_QCONTPOISSON:
@@ -820,7 +821,7 @@ int inla_read_data_likelihood(inla_tp *mb, dictionary *UNUSED(ini), int UNUSED(s
 		Free(ds->data_observations.weight_gaussian);
 	}
 
-	if (ds->data_id == L_POISSON || ds->data_id == L_XPOISSON || ds->data_id == L_NPOISSON) {
+	if (ds->data_id == L_POISSON || ds->data_id == L_XPOISSON || ds->data_id == L_NPOISSON || ds->data_id == L_POISSONLOGNORMAL) {
 		n = mb->predictor_ndata;
 		int nnuma = GMRFLib_numa_nodes();
 		inla_llik_data_poisson_tp **p = Calloc(nnuma, inla_llik_data_poisson_tp *);
@@ -2752,6 +2753,131 @@ int loglikelihood_poisson(int thread_id, int *UNUSED(lcache_idx), double *__rest
 	return GMRFLib_SUCCESS;
 }
 #pragma GCC diagnostic pop
+
+int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), double *__restrict logll, double *__restrict x, int m, int idx,
+				   double *UNUSED(x_vec), double *UNUSED(y_cdf), void *arg)
+{
+#define PLN_GHQ_N 50
+#define _pln_logE(E_) ((E_) > 0.0 ? log(E_) : 0.0)
+
+	/*
+	 * y ~ Poisson(E * exp(eta + u)),  u ~ N(0, 1/prec),  v = u*sqrt(prec) ~ N(0,1),  sd = 1/sqrt(prec)
+	 *
+	 * log I = log sigma_a + logsumexp_k [ log(w_k) + normc + y*(eta+vk*sd) - E*exp(eta+vk*sd) - vk^2/2 + xq[k]^2/2 ]
+	 *
+	 * Fixed-reference adaptive GHQ (solution 2):
+	 *   Compute v*(eta_ref) via Newton once (eta_ref from x[m/2]).
+	 *   sigma_a = 1/sqrt(mu_star*sd^2+1).
+	 *   Fix nodes vk[k] = v* + xq[k]*sigma_a for all m evaluations.
+	 *   Since vk does NOT depend on eta_i, d/d(eta_i)[eta_i+vk*sd] = 1 (correct gradient).
+	 *   Nodes are placed near the posterior mode → accurate for large rates.
+	 */
+	if (m == 0) {
+		return GMRFLib_SUCCESS;
+	}
+
+	int numa = GMRFLib_numa_get_node();
+	Data_section_tp *ds = (Data_section_tp *) arg;
+	inla_llik_data_poisson_tp *p = &(ds->data_observations.data_poisson[numa][idx]);
+	double y = p->y;
+	double E = p->E;
+	double normc = p->normc;
+
+	if (ISNAN(normc)) {
+		normc = p->normc = y * _pln_logE(E) - my_gsl_sf_lnfact((int) y);
+	}
+
+	double log_prec = ds->data_observations.pln_log_prec[thread_id][0];
+	double sd = exp(-0.5 * log_prec);		       /* sd = 1/sqrt(prec) */
+	double sd2 = sd * sd;
+
+	int nq = PLN_GHQ_N;
+	double *xq = NULL, *wq = NULL;
+	GMRFLib_ghq(&xq, &wq, nq);
+
+	LINK_INIT;
+
+	if (m > 0) {
+		/* Reference eta from the middle evaluation point */
+		double eta_ref = PREDICTOR_INVERSE_IDENTITY_LINK(x[m / 2], off);
+
+		/* Newton's method: find v* = argmax [ y*(eta_ref+v*sd) - E*exp(eta_ref+v*sd) - v^2/2 ]
+		 * g'(v)  = (y - mu_v)*sd - v,  where mu_v = E*exp(eta_ref+v*sd)
+		 * g''(v) = -(mu_v*sd^2 + 1)
+		 * Update: v -= g'(v)/g''(v)
+		 * Initialise at the Poisson mode (ignoring the v^2/2 regulariser) to avoid
+		 * huge first Newton steps when eta_ref is far from the truth. */
+		double v_star;
+		if (y > 0.0) {
+			/* Start at the Poisson mode (mu=y), ignoring the v^2/2 regulariser.
+			 * This gives a small first Newton step even when eta_ref is far from truth. */
+			v_star = (log(y / fmax(E, 1e-300)) - eta_ref) / sd;
+			v_star = fmax(-30.0, fmin(30.0, v_star));
+		} else {
+			/* For y=0 the Poisson mode is mu→0; start at v=0 (regulariser dominates). */
+			v_star = 0.0;
+		}
+		for (int iter = 0; iter < 30; iter++) {
+			double eta_v = eta_ref + v_star * sd;
+			double mu_v = (eta_v < 500.0) ? E * exp(eta_v) : E * exp(500.0);
+			double gp = (y - mu_v) * sd - v_star;
+			double gpp = -(mu_v * sd2 + 1.0);
+			double dv = -gp / gpp;
+			/* clamp step for robustness */
+			dv = fmax(-5.0, fmin(5.0, dv));
+			v_star += dv;
+			if (fabs(dv) < 1e-8) {
+				break;
+			}
+		}
+
+		double mu_star = E * exp(eta_ref + v_star * sd);
+		double sigma_a = 1.0 / sqrt(mu_star * sd2 + 1.0);
+		double log_sigma_a = -0.5 * log(mu_star * sd2 + 1.0);
+
+		/* Fixed quadrature nodes in v-space (do NOT depend on eta_i) */
+		double vk[PLN_GHQ_N];
+		double log_wq[PLN_GHQ_N];
+		double xq2[PLN_GHQ_N];
+		double vk2[PLN_GHQ_N];
+		for (int k = 0; k < nq; k++) {
+			vk[k] = v_star + xq[k] * sigma_a;
+			log_wq[k] = log(wq[k]);
+			xq2[k] = xq[k] * xq[k];
+			vk2[k] = vk[k] * vk[k];
+		}
+
+		for (int i = 0; i < m; i++) {
+			double eta_i = PREDICTOR_INVERSE_IDENTITY_LINK(x[i], off);
+
+			double vmax = -INFINITY;
+			double vals[PLN_GHQ_N];
+
+			for (int k = 0; k < nq; k++) {
+				double eta_k = eta_i + vk[k] * sd;
+				double mu_k = E * exp(eta_k);
+				/* log p(y|eta_k) - vk^2/2 + xq_k^2/2 */
+				vals[k] = log_wq[k] + normc + y * eta_k - mu_k - 0.5 * vk2[k] + 0.5 * xq2[k];
+				if (vals[k] > vmax) {
+					vmax = vals[k];
+				}
+			}
+
+			double sum = 0.0;
+			for (int k = 0; k < nq; k++) {
+				if (!ISNAN(vals[k])) {
+					sum += exp(vals[k] - vmax);
+				}
+			}
+			logll[i] = log_sigma_a + vmax + log(sum);
+		}
+	}
+
+	LINK_END;
+#undef PLN_GHQ_N
+#undef _pln_logE
+	return GMRFLib_SUCCESS;
+}
 
 int loglikelihood_npoisson(int thread_id, int *UNUSED(lcache_idx), double *__restrict logll, double *__restrict x, int m, int idx,
 			   double *UNUSED(x_vec), double *y_cdf, void *arg)

--- a/inlaprog/src/inla-likelihood.c
+++ b/inlaprog/src/inla-likelihood.c
@@ -2757,7 +2757,6 @@ int loglikelihood_poisson(int thread_id, int *UNUSED(lcache_idx), double *__rest
 int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), double *__restrict logll, double *__restrict x, int m, int idx,
 				   double *UNUSED(x_vec), double *UNUSED(y_cdf), void *arg)
 {
-#define PLN_GHQ_N 50
 #define _pln_logE(E_) ((E_) > 0.0 ? log(E_) : 0.0)
 
 	/*
@@ -2765,12 +2764,12 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 	 *
 	 * log I = log sigma_a + logsumexp_k [ log(w_k) + normc + y*(eta+vk*sd) - E*exp(eta+vk*sd) - vk^2/2 + xq[k]^2/2 ]
 	 *
-	 * Fixed-reference adaptive GHQ (solution 2):
+	 * Fixed-reference adaptive GHQ:
 	 *   Compute v*(eta_ref) via Newton once (eta_ref from x[m/2]).
 	 *   sigma_a = 1/sqrt(mu_star*sd^2+1).
 	 *   Fix nodes vk[k] = v* + xq[k]*sigma_a for all m evaluations.
 	 *   Since vk does NOT depend on eta_i, d/d(eta_i)[eta_i+vk*sd] = 1 (correct gradient).
-	 *   Nodes are placed near the posterior mode → accurate for large rates.
+	 *   Nodes are placed near the posterior mode -- accurate for all rate regimes.
 	 */
 	if (m == 0) {
 		return GMRFLib_SUCCESS;
@@ -2791,40 +2790,40 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 	double sd = exp(-0.5 * log_prec);		       /* sd = 1/sqrt(prec) */
 	double sd2 = sd * sd;
 
-	int nq = PLN_GHQ_N;
+	int nq = ds->data_observations.pln_nquad;
 	double *xq = NULL, *wq = NULL;
 	GMRFLib_ghq(&xq, &wq, nq);
 
+	/* Per-call working arrays allocated on the heap (size is user-controlled, malloc is portable C89). */
+	double *vk     = Malloc(nq, double);
+	double *log_wq = Malloc(nq, double);
+	double *xq2    = Malloc(nq, double);
+	double *vk2    = Malloc(nq, double);
+	double *vals   = Malloc(nq, double);
+
 	LINK_INIT;
 
-	if (m > 0) {
+	{
 		/* Reference eta from the middle evaluation point */
 		double eta_ref = PREDICTOR_INVERSE_IDENTITY_LINK(x[m / 2], off);
 
-		/* Newton's method: find v* = argmax [ y*(eta_ref+v*sd) - E*exp(eta_ref+v*sd) - v^2/2 ]
-		 * g'(v)  = (y - mu_v)*sd - v,  where mu_v = E*exp(eta_ref+v*sd)
-		 * g''(v) = -(mu_v*sd^2 + 1)
-		 * Update: v -= g'(v)/g''(v)
-		 * Initialise at the Poisson mode (ignoring the v^2/2 regulariser) to avoid
-		 * huge first Newton steps when eta_ref is far from the truth. */
+		/* Newton: find v* = argmax [ y*(eta_ref+v*sd) - E*exp(eta_ref+v*sd) - v^2/2 ]
+		 * Initialise at the Poisson mode (mu=y) to keep the first step small even when
+		 * eta_ref is far from the truth (starting at v=0 can give a step of ~y/mu_0). */
 		double v_star;
+		int iter;
 		if (y > 0.0) {
-			/* Start at the Poisson mode (mu=y), ignoring the v^2/2 regulariser.
-			 * This gives a small first Newton step even when eta_ref is far from truth. */
 			v_star = (log(y / fmax(E, 1e-300)) - eta_ref) / sd;
 			v_star = fmax(-30.0, fmin(30.0, v_star));
 		} else {
-			/* For y=0 the Poisson mode is mu→0; start at v=0 (regulariser dominates). */
 			v_star = 0.0;
 		}
-		for (int iter = 0; iter < 30; iter++) {
+		for (iter = 0; iter < 30; iter++) {
 			double eta_v = eta_ref + v_star * sd;
 			double mu_v = (eta_v < 500.0) ? E * exp(eta_v) : E * exp(500.0);
 			double gp = (y - mu_v) * sd - v_star;
 			double gpp = -(mu_v * sd2 + 1.0);
-			double dv = -gp / gpp;
-			/* clamp step for robustness */
-			dv = fmax(-5.0, fmin(5.0, dv));
+			double dv = fmax(-5.0, fmin(5.0, -gp / gpp));
 			v_star += dv;
 			if (fabs(dv) < 1e-8) {
 				break;
@@ -2835,28 +2834,22 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 		double sigma_a = 1.0 / sqrt(mu_star * sd2 + 1.0);
 		double log_sigma_a = -0.5 * log(mu_star * sd2 + 1.0);
 
-		/* Fixed quadrature nodes in v-space (do NOT depend on eta_i) */
-		double vk[PLN_GHQ_N];
-		double log_wq[PLN_GHQ_N];
-		double xq2[PLN_GHQ_N];
-		double vk2[PLN_GHQ_N];
-		for (int k = 0; k < nq; k++) {
-			vk[k] = v_star + xq[k] * sigma_a;
+		int k;
+		for (k = 0; k < nq; k++) {
+			vk[k]     = v_star + xq[k] * sigma_a;
 			log_wq[k] = log(wq[k]);
-			xq2[k] = xq[k] * xq[k];
-			vk2[k] = vk[k] * vk[k];
+			xq2[k]    = xq[k] * xq[k];
+			vk2[k]    = vk[k] * vk[k];
 		}
 
-		for (int i = 0; i < m; i++) {
+		int i;
+		for (i = 0; i < m; i++) {
 			double eta_i = PREDICTOR_INVERSE_IDENTITY_LINK(x[i], off);
-
 			double vmax = -INFINITY;
-			double vals[PLN_GHQ_N];
 
-			for (int k = 0; k < nq; k++) {
+			for (k = 0; k < nq; k++) {
 				double eta_k = eta_i + vk[k] * sd;
 				double mu_k = E * exp(eta_k);
-				/* log p(y|eta_k) - vk^2/2 + xq_k^2/2 */
 				vals[k] = log_wq[k] + normc + y * eta_k - mu_k - 0.5 * vk2[k] + 0.5 * xq2[k];
 				if (vals[k] > vmax) {
 					vmax = vals[k];
@@ -2864,7 +2857,7 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 			}
 
 			double sum = 0.0;
-			for (int k = 0; k < nq; k++) {
+			for (k = 0; k < nq; k++) {
 				if (!ISNAN(vals[k])) {
 					sum += exp(vals[k] - vmax);
 				}
@@ -2874,7 +2867,13 @@ int loglikelihood_poissonlognormal(int thread_id, int *UNUSED(lcache_idx), doubl
 	}
 
 	LINK_END;
-#undef PLN_GHQ_N
+
+	Free(vk);
+	Free(log_wq);
+	Free(xq2);
+	Free(vk2);
+	Free(vals);
+
 #undef _pln_logE
 	return GMRFLib_SUCCESS;
 }

--- a/inlaprog/src/inla-parse.c
+++ b/inlaprog/src/inla-parse.c
@@ -923,6 +923,10 @@ int inla_parse_data(inla_tp *mb, dictionary *ini, int sec)
 		ds->loglikelihood = (GMRFLib_logl_tp *) loglikelihood_poisson;
 		ds->data_id = L_POISSON;
 		discrete_data = 1;
+	} else if (!strcasecmp(ds->data_likelihood, "POISSONLOGNORMAL")) {
+		ds->loglikelihood = (GMRFLib_logl_tp *) loglikelihood_poissonlognormal;
+		ds->data_id = L_POISSONLOGNORMAL;
+		discrete_data = 1;
 	} else if (!strcasecmp(ds->data_likelihood, "NPOISSON")) {
 		ds->loglikelihood = (GMRFLib_logl_tp *) loglikelihood_npoisson;
 		ds->data_id = L_NPOISSON;
@@ -1672,6 +1676,7 @@ int inla_parse_data(inla_tp *mb, dictionary *ini, int sec)
 	case L_POISSON:
 	case L_XPOISSON:
 	case L_NPOISSON:
+	case L_POISSONLOGNORMAL:
 	{
 		Free(ds->data_observations.y);
 		Free(ds->data_observations.E);
@@ -3142,6 +3147,53 @@ int inla_parse_data(inla_tp *mb, dictionary *ini, int sec)
 	case L_NPOISSON:
 	case L_XPOISSON:
 	case L_CONTPOISSON:
+		break;
+
+	case L_POISSONLOGNORMAL:
+	{
+		/*
+		 * get options related to the Poisson log-normal (GHQ) likelihood
+		 */
+		tmp = iniparser_getdouble(ini, inla_string_join(secname, "INITIAL"), 0.0);
+		ds->data_fixed = iniparser_getboolean(ini, inla_string_join(secname, "FIXED"), 0);
+		if (!ds->data_fixed && mb->mode_use_mode) {
+			tmp = mb->theta_file[mb->theta_counter_file++];
+			if (mb->mode_fixed)
+				ds->data_fixed = 1;
+		}
+		HYPER_NEW(ds->data_observations.pln_log_prec, tmp);
+		if (mb->verbose) {
+			printf("\t\tinitialise pln_log_prec[%g]\n", ds->data_observations.pln_log_prec[0][0]);
+			printf("\t\tfixed=[%1d]\n", ds->data_fixed);
+		}
+		inla_read_prior(mb, ini, sec, &(ds->data_prior), "PCPREC", NULL);
+
+		if (!ds->data_fixed) {
+			mb->theta = Realloc(mb->theta, mb->ntheta + 1, double **);
+			mb->theta_hyperid = Realloc(mb->theta_hyperid, mb->ntheta + 1, char *);
+			mb->theta_hyperid[mb->ntheta] = ds->data_prior.hyperid;
+			mb->theta_tag = Realloc(mb->theta_tag, mb->ntheta + 1, char *);
+			mb->theta_tag_userscale = Realloc(mb->theta_tag_userscale, mb->ntheta + 1, char *);
+			mb->theta_dir = Realloc(mb->theta_dir, mb->ntheta + 1, char *);
+			mb->theta_tag[mb->ntheta] = inla_make_tag("Log precision for poissonlognormal", mb->ds);
+			mb->theta_tag_userscale[mb->ntheta] = inla_make_tag("Precision for poissonlognormal", mb->ds);
+			GMRFLib_sprintf(&msg, "%s-parameter", secname);
+			mb->theta_dir[mb->ntheta] = msg;
+
+			mb->theta_from = Realloc(mb->theta_from, mb->ntheta + 1, char *);
+			mb->theta_to = Realloc(mb->theta_to, mb->ntheta + 1, char *);
+			mb->theta_from[mb->ntheta] = Strdup(ds->data_prior.from_theta);
+			mb->theta_to[mb->ntheta] = Strdup(ds->data_prior.to_theta);
+
+			mb->theta[mb->ntheta] = ds->data_observations.pln_log_prec;
+			mb->theta_map = Realloc(mb->theta_map, mb->ntheta + 1, map_func_tp *);
+			mb->theta_map[mb->ntheta] = map_precision;
+			mb->theta_map_arg = Realloc(mb->theta_map_arg, mb->ntheta + 1, void *);
+			mb->theta_map_arg[mb->ntheta] = NULL;
+			mb->ntheta++;
+			ds->data_ntheta++;
+		}
+	}
 		break;
 
 	case L_QCONTPOISSON:

--- a/inlaprog/src/inla-parse.c
+++ b/inlaprog/src/inla-parse.c
@@ -3162,9 +3162,11 @@ int inla_parse_data(inla_tp *mb, dictionary *ini, int sec)
 				ds->data_fixed = 1;
 		}
 		HYPER_NEW(ds->data_observations.pln_log_prec, tmp);
+		ds->data_observations.pln_nquad = iniparser_getint(ini, inla_string_join(secname, "NQUAD"), 50);
 		if (mb->verbose) {
 			printf("\t\tinitialise pln_log_prec[%g]\n", ds->data_observations.pln_log_prec[0][0]);
 			printf("\t\tfixed=[%1d]\n", ds->data_fixed);
+			printf("\t\tpln_nquad=[%1d]\n", ds->data_observations.pln_nquad);
 		}
 		inla_read_prior(mb, ini, sec, &(ds->data_prior), "PCPREC", NULL);
 

--- a/inlaprog/src/inla-parse.c
+++ b/inlaprog/src/inla-parse.c
@@ -3162,7 +3162,7 @@ int inla_parse_data(inla_tp *mb, dictionary *ini, int sec)
 				ds->data_fixed = 1;
 		}
 		HYPER_NEW(ds->data_observations.pln_log_prec, tmp);
-		ds->data_observations.pln_nquad = iniparser_getint(ini, inla_string_join(secname, "NQUAD"), 50);
+		ds->data_observations.pln_nquad = iniparser_getint(ini, inla_string_join(secname, "NQUAD"), 15);
 		if (mb->verbose) {
 			printf("\t\tinitialise pln_log_prec[%g]\n", ds->data_observations.pln_log_prec[0][0]);
 			printf("\t\tfixed=[%1d]\n", ds->data_fixed);

--- a/inlaprog/src/inla.c
+++ b/inlaprog/src/inla.c
@@ -2693,6 +2693,16 @@ double extra(int thread_id, double *theta, int ntheta, void *argument, GMRFLib_s
 			case L_QCONTPOISSON:
 				break;
 
+			case L_POISSONLOGNORMAL:
+			{
+				if (!ds->data_fixed) {
+					double log_prec = theta[count];
+					val += PRIOR_EVAL(ds->data_prior, &log_prec);
+					count++;
+				}
+			}
+				break;
+
 			case L_EXPONENTIALSURV:
 			case L_GAMMAJWSURV:
 			{

--- a/inlaprog/src/inla.h
+++ b/inlaprog/src/inla.h
@@ -741,6 +741,7 @@ typedef struct {
 	 * Poisson log-normal (GHQ): y ~ Poisson(E*exp(eta+u)), u ~ N(0, 1/prec)
 	 */
 	double **pln_log_prec;
+	int pln_nquad;
 
 	/*
 	 * cencored poisson. values in [interval[0], interval[1]] are cencored

--- a/inlaprog/src/inla.h
+++ b/inlaprog/src/inla.h
@@ -252,6 +252,7 @@ typedef enum {
 	L_GAMMACOUNTMEAN,
 	L_0NBINOMIAL,
 	L_0NBINOMIALS,
+	L_POISSONLOGNORMAL,				       /* Poisson log-normal (GHQ) */
 	F_RW2D = 1000,					       /* f-models */
 	F_BESAG,
 	F_BESAG2,					       /* the [a*x, x/a] model */
@@ -735,6 +736,11 @@ typedef struct {
 	 */
 	double **gpoisson_overdispersion;
 	double **gpoisson_p;
+
+	/*
+	 * Poisson log-normal (GHQ): y ~ Poisson(E*exp(eta+u)), u ~ N(0, 1/prec)
+	 */
+	double **pln_log_prec;
 
 	/*
 	 * cencored poisson. values in [interval[0], interval[1]] are cencored
@@ -2385,6 +2391,7 @@ int loglikelihood_occupancy(int thread_id, int *lcache_idx, double *__restrict l
 int loglikelihood_obeta(int thread_id, int *lcache_idx, double *__restrict logll, double *__restrict x, int m, int idx, double *UNUSED(x_vec),
 			double *y_cdf, void *arg);
 int loglikelihood_poisson(int thread_id, int *lcache_idx, double *logll, double *x, int m, int idx, double *x_vec, double *y_cdf, void *arg);
+int loglikelihood_poissonlognormal(int thread_id, int *lcache_idx, double *logll, double *x, int m, int idx, double *x_vec, double *y_cdf, void *arg);
 int loglikelihood_poisson_special1(int thread_id, int *lcache_idx, double *logll, double *x, int m, int idx, double *x_vec, double *y_cdf,
 				   void *arg);
 int loglikelihood_pom(int thread_id, int *lcache_idx, double *logll, double *x, int m, int idx, double *x_vec, double *y_cdf, void *arg);

--- a/rinla/R/create.data.file.R
+++ b/rinla/R/create.data.file.R
@@ -172,6 +172,7 @@
                                        "gammacount",
                                        "gpoisson",
                                        "xpoisson",
+                                       "poissonlognormal",
                                        "zeroinflatedcenpoisson0",
                                        "zeroinflatedcenpoisson1",
                                        "zeroinflatednbinomial0",

--- a/rinla/R/models.R
+++ b/rinla/R/models.R
@@ -9523,7 +9523,7 @@
                 ),
 
                 poissonlognormal = list(
-                    doc = "The Poisson log-normal likelihood: y ~ Poisson(E*exp(eta+u)), u ~ N(0, 1/prec). The random effect u is integrated out analytically using Gauss-Hermite quadrature.",
+                    doc = "The Poisson log-normal likelihood: y ~ Poisson(E*exp(eta+u)), u ~ N(0, 1/prec). The random effect u is integrated out analytically using fixed-reference adaptive Gauss-Hermite quadrature (default 15 points; set nquad in control.family to adjust).",
                     hyper = list(
                         theta = list(
                             hyperid = 57001,

--- a/rinla/R/models.R
+++ b/rinla/R/models.R
@@ -9522,6 +9522,29 @@
                     pdf = "gpoisson"
                 ),
 
+                poissonlognormal = list(
+                    doc = "The Poisson log-normal likelihood: y ~ Poisson(E*exp(eta+u)), u ~ N(0, 1/prec). The random effect u is integrated out analytically using Gauss-Hermite quadrature.",
+                    hyper = list(
+                        theta = list(
+                            hyperid = 57001,
+                            name = "log precision",
+                            short.name = "prec",
+                            output.name = "Precision for poissonlognormal",
+                            output.name.intern = "Log precision for poissonlognormal",
+                            initial = 0,
+                            fixed = FALSE,
+                            prior = "pc.prec",
+                            param = c(1, 0.01),
+                            to.theta = function(x) log(x),
+                            from.theta = function(x) exp(x)
+                        )
+                    ),
+                    survival = FALSE,
+                    discrete = TRUE,
+                    link = c("default", "log", "logoffset"),
+                    pdf = "poissonlognormal"
+                ),
+
                 poisson.special1 = list(
                     doc = "The Poisson.special1 likelihood",
                     hyper = list(

--- a/rinla/R/sections.R
+++ b/rinla/R/sections.R
@@ -304,6 +304,14 @@ inla.parse.Bmatrix.test <- function() {
         }
     }
 
+    if (inla.one.of(family, "poissonlognormal")) {
+        nquad <- inla.ifelse(is.null(control$nquad), 50L, as.integer(control$nquad))
+        if (nquad < 1L) {
+            stop("control.family: nquad must be a positive integer")
+        }
+        cat("nquad = ", nquad, "\n", sep = "", file = file, append = TRUE)
+    }
+
     inla.write.hyper(control$hyper, file, data.dir = data.dir)
 
     ## this is for 0poisson etc... that use argument link.simpple

--- a/rinla/R/sections.R
+++ b/rinla/R/sections.R
@@ -305,7 +305,7 @@ inla.parse.Bmatrix.test <- function() {
     }
 
     if (inla.one.of(family, "poissonlognormal")) {
-        nquad <- inla.ifelse(is.null(control$nquad), 50L, as.integer(control$nquad))
+        nquad <- inla.ifelse(is.null(control$nquad), 15L, as.integer(control$nquad))
         if (nquad < 1L) {
             stop("control.family: nquad must be a positive integer")
         }

--- a/rinla/R/set.default.arguments.R
+++ b/rinla/R/set.default.arguments.R
@@ -587,8 +587,8 @@ control.gcpo <-
              beta.censor.value = 0.0,
 
              #' @param nquad Number of Gauss-Hermite quadrature points for the
-             #' `poissonlognormal` likelihood (default 50).
-             nquad = 50L,
+             #' `poissonlognormal` likelihood (default 15).
+             nquad = 15L,
 
              #' @param variant This variable is used to give options for various variants of
              #' the likelihood,  like chosing different parameterisations for example. See the

--- a/rinla/R/set.default.arguments.R
+++ b/rinla/R/set.default.arguments.R
@@ -586,6 +586,10 @@ control.gcpo <-
              #' <= beta.censor.value < 1/2)`
              beta.censor.value = 0.0,
 
+             #' @param nquad Number of Gauss-Hermite quadrature points for the
+             #' `poissonlognormal` likelihood (default 50).
+             nquad = 50L,
+
              #' @param variant This variable is used to give options for various variants of
              #' the likelihood,  like chosing different parameterisations for example. See the
              #' relevant likelihood documentations for options (does only apply to some

--- a/rinla/tests/testthat/test-poissonlognormal.R
+++ b/rinla/tests/testthat/test-poissonlognormal.R
@@ -1,0 +1,82 @@
+context("test 'likelihood poissonlognormal'")
+
+## Case 1: intercept recovery
+## Simulate y_i ~ Poisson(exp(beta0 + u_i)), u_i ~ N(0, 1/prec_true).
+## Check that the posterior mean of the intercept is close to the truth.
+test_that("Case 1: intercept recovery", {
+    set.seed(123)
+    n         <- 500
+    beta0     <- 1.0
+    sigma     <- 1.0
+    y         <- rpois(n, exp(beta0 + rnorm(n, 0, sigma)))
+    r         <- inla(y ~ 1,
+                      family          = "poissonlognormal",
+                      data            = data.frame(y = y),
+                      control.compute = list(dic = TRUE))
+    expect_true(abs(r$summary.fixed[1L, "mean"] - beta0) < 0.05)
+})
+
+## Case 2: precision recovery
+## Same generative model; check that the posterior mean of the
+## lognormal precision hyperparameter is close to 1/sigma^2.
+test_that("Case 2: precision recovery", {
+    set.seed(123)
+    n         <- 500
+    beta0     <- 1.0
+    sigma     <- 1.0
+    prec_true <- 1 / sigma^2
+    y         <- rpois(n, exp(beta0 + rnorm(n, 0, sigma)))
+    r         <- inla(y ~ 1,
+                      family          = "poissonlognormal",
+                      data            = data.frame(y = y),
+                      control.compute = list(dic = TRUE))
+    expect_true(abs(r$summary.hyperpar[1L, "mean"] - prec_true) < 0.3)
+})
+
+## Case 3: marginal likelihood
+## For n=1 with fixed precision, INLA's log-marginal-likelihood must match
+## the true value obtained by numerically integrating out the intercept.
+##
+## True p(y) = integral_eta  p_PLN(y | eta, prec_fixed) * N(eta; a, b^2) d_eta
+##
+## where p_PLN(y | eta, prec_fixed)
+##       = integral_u  Poisson(y; exp(eta+u)) * N(u; 0, 1/prec_fixed) du
+test_that("Case 3: marginal likelihood vs numerical integral", {
+    y_obs      <- 3L
+    E_obs      <- 1.0
+    prec_fixed <- 1.0
+    a          <- 0.0          ## prior mean on intercept
+    b          <- 1.38         ## prior sd on intercept (matches test-poisson.R)
+
+    ## true marginal likelihood by double numerical integration
+    sd_fixed <- 1 / sqrt(prec_fixed)
+    pln_lik  <- function(eta) {
+        vapply(eta, function(e) {
+            integrate(
+                function(u) dpois(y_obs, E_obs * exp(e + u)) * dnorm(u, 0, sd_fixed),
+                lower = -20, upper = 20
+            )$value
+        }, numeric(1L))
+    }
+    fac       <- 15
+    eta_lo    <- a - fac * b
+    eta_hi    <- a + fac * b
+    true_mlik <- log(
+        integrate(function(eta) pln_lik(eta) * dnorm(eta, a, b),
+                  lower = eta_lo, upper = eta_hi)$value
+    )
+
+    ## INLA marginal likelihood with the same fixed precision and prior
+    r <- inla(y ~ 1,
+              family          = "poissonlognormal",
+              data            = data.frame(y = y_obs),
+              control.compute = list(mlik = TRUE),
+              control.fixed   = list(mean.intercept  = a,
+                                     prec.intercept  = 1 / b^2),
+              control.family  = list(hyper = list(
+                  prec = list(fixed = TRUE, initial = log(prec_fixed))
+              )),
+              control.inla    = list(strategy = "laplace"))
+
+    expect_equal(r$mlik[[1L]], true_mlik, tolerance = 1e-2)
+})


### PR DESCRIPTION
I'm working on a scientific project involving single cell rna sequencing with sparse data for which I am using a Poisson likelihood, with iid effects as well as other structured effects (e.g., spatial, but the full details are not necessary here). I prefer structured effects + iid with a Poisson likelihood to structured effects alone with a negative binomial likelihood because the former makes it much easier to compare the relative importance of the structured and iid effects. 

However, I often notice that when fitting the model to genes with particularly sparse counts, I get `'vb.correction' is aborted` warnings. In some simulations, I have found that in these cases the fits can be quite bad relative to mcmc.

It struck me that in these models, perhaps the most challenging aspect is estimating the posterior distribution over the iid effects, which can often have a long left tail. It serves to reason that integrating out these iid effects might then make posterior inference easier.

Below, I've implemented the Poisson log-normal distribution, using adaptive Gauss-Hermite quadrature to numerically evaluate the likelihood.

If you run the example below, you will see in the second case with small rates that the new Poisson log-normal likelihood recovers substantially more accurate parameter estimates than the Poisson + iid model, which throws a vb.correction warning.

```
## Test Poisson log-normal likelihood
## Compares:
##   Model 1: Poisson + per-observation iid random effect (reference)
##   Model 2: poissonlognormal likelihood across nquad = 10, 25, 50

library(INLA)

pln_summary <- function(m, label) {
    cat(sprintf("  %-20s intercept=%.4f  prec=%.4f  DIC=%.1f\n",
                label,
                m$summary.fixed[1, "mean"],
                inla.mmarginal(m$marginals.hyperpar[[1]]),
                m$dic$dic))
}

## ============================================================
## Large-rate data  (beta0=5, sigma=1, mean(y) ~ 231)
## ============================================================
cat("=== Large-rate data (beta0=5, sigma=1) ===\n")
set.seed(42)
n          <- 500
beta0_true <- 5.0
sigma_true <- 1.0
prec_true  <- 1 / sigma_true^2

u <- rnorm(n, 0, sigma_true)
y <- rpois(n, exp(beta0_true + u))
cat(sprintf("  n=%d  mean(y)=%.1f  fraction zero=%.3f\n\n",
            n, mean(y), mean(y == 0)))

cat("  True: intercept=5.0  prec=1.0\n\n")

## Poisson + iid (reference)
idx <- 1:n
m1 <- inla(y ~ 1 + f(idx, model = "iid"),
           family          = "poisson",
           data            = data.frame(y = y, idx = idx),
           control.compute = list(dic = TRUE))
pln_summary(m1, "Poisson+iid")

## poissonlognormal across nquad values
for (nq in c(10L, 15L, 25L, 50L)) {
    m <- inla(y ~ 1,
              family          = "poissonlognormal",
              data            = data.frame(y = y),
              control.family  = list(nquad = nq),
              control.compute = list(dic = TRUE))
    pln_summary(m, sprintf("PLN nquad=%d", nq))
}

## ============================================================
## Sparse data  (beta0=-3.5, sigma=2, ~89% zeros)
## ============================================================
cat("\n=== Sparse data (beta0=-3.5, sigma=2) ===\n")
set.seed(123)
n_s          <- 10000
beta0_sparse <- -3.5
sigma_sparse <- 2.0
prec_sparse  <- 1 / sigma_sparse^2

u_s <- rnorm(n_s, 0, sigma_sparse)
y_s <- rpois(n_s, exp(beta0_sparse + u_s))
cat(sprintf("  n=%d  mean(y)=%.4f  fraction zero=%.3f\n\n",
            n_s, mean(y_s), mean(y_s == 0)))

cat(sprintf("  True: intercept=%.1f  prec=%.4f\n\n", beta0_sparse, prec_sparse))

## Poisson + iid (reference)
idx_s <- 1:n_s
m1s <- inla(y ~ 1 + f(idx, model = "iid"),
            family          = "poisson",
            data            = data.frame(y = y_s, idx = idx_s),
            control.compute = list(dic = TRUE),
            safe            = TRUE)
pln_summary(m1s, "Poisson+iid")

## poissonlognormal across nquad values
for (nq in c(10L, 15L, 25L, 50L)) {
    m <- inla(y ~ 1,
              family          = "poissonlognormal",
              data            = data.frame(y = y_s),
              control.family  = list(nquad = nq),
              control.compute = list(dic = TRUE))
    pln_summary(m, sprintf("PLN nquad=%d", nq))
}

cat("\n=== Done ===\n")
```



